### PR TITLE
Add support for deserialization via serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ A library to generate and parse UUIDs.
 
 [dependencies]
 rustc-serialize = "0.3"
+serde = { version = "^0.5.0", optional = true }
 rand = "0.3"


### PR DESCRIPTION
This PR brings support for `serde`. It can be optionally enabled to avoid the dependency on `serde` if it's not used. The cargo feature flag is called `serde`.

A `Uuid` is serialized to and deserialized from it's hyphenated string representation like the `rustc_serialize` implementation does. Additionally a `Uuid` can be deserialized from it's 16-bytes representation.

There are no tests for this functionality currently, should I add some tests using `serde_json` as dev-dependency for example?