### PR TITLE
Update dependency `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ A library to generate and parse UUIDs.
 
 [dependencies]
 rustc-serialize = "0.3"
-serde = { version = "^0.5.0", optional = true }
+serde = { version = "^0.6.0", optional = true }
 rand = "0.3"


### PR DESCRIPTION
Only a simple version update. No breakage expected because the feature `serde` wasn't released yet.